### PR TITLE
Add Whistle deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Whistle Home Assistant Integration
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs) ![GitHub manifest version (path)](https://img.shields.io/github/manifest-json/v/RobertD502/home-assistant-whistle?filename=custom_components%2Fwhistle%2Fmanifest.json)
 
+## ⚠️ IMPORTANT NOTICE - Platform Decommission
+
+**The Whistle platform will be decommissioned on September 1st, 2025.** This integration will no longer function after that date. We recommend migrating to [Tractive GPS](https://tractive.com), which offers a native [Home Assistant integration](https://www.home-assistant.io/integrations/tractive/) and has a special migration offer for Whistle customers. For details see [whistle.com](https://whistle.com). 
+
 <a href="https://www.buymeacoffee.com/RobertD502" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="100" width="424"></a>
 <a href="https://liberapay.com/RobertD502/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg" height="100" width="300"></a>
 

--- a/custom_components/whistle/__init__.py
+++ b/custom_components/whistle/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 
 from .const import (
     CONF_ZONE_METHOD,
@@ -19,6 +20,16 @@ from .coordinator import WhistleDataUpdateCoordinator
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """ Set up Whistle from a config entry. """
+
+    # Create deprecation notification
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "whistle_platform_decommission",
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="whistle_platform_decommission",
+    )
 
     coordinator = WhistleDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/whistle/manifest.json
+++ b/custom_components/whistle/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/RobertD502/home-assistant-whistle/issues",
   "requirements": ["whistleaio==0.1.2", "strenum==0.4.8"],
-  "version": "0.1.10"
+  "version": "0.2.0"
 }

--- a/custom_components/whistle/strings.json
+++ b/custom_components/whistle/strings.json
@@ -36,5 +36,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "whistle_platform_decommission": {
+      "title": "Whistle Platform Decommission Notice",
+      "description": "The Whistle platform will be decommissioned on September 1st, 2025. This integration will no longer function after that date. We recommend migrating to Tractive GPS, which offers a Home Assistant integration and has a special migration offer for Whistle customers. For details see whistle.com."
+    }
   }
 }

--- a/custom_components/whistle/translations/en.json
+++ b/custom_components/whistle/translations/en.json
@@ -36,5 +36,11 @@
                 }
             }
         }
+    },
+    "issues": {
+        "whistle_platform_decommission": {
+            "title": "Whistle Platform Decommission Notice",
+            "description": "The Whistle platform will be decommissioned on September 1st, 2025. This integration will no longer function after that date. We recommend migrating to Tractive GPS, which offers a Home Assistant integration and has a special migration offer for Whistle customers. Details can be found at whistle.com"
+        }
     }
 }


### PR DESCRIPTION
Inform users that this integration will stop working in September 2025:
* in this project's README
* in Home Assistant through a notification

This is how the notice will look like:
<img width="568" height="278" alt="image" src="https://github.com/user-attachments/assets/306a6a09-20c8-4a3c-81b3-6ddff45cdcdf" />
